### PR TITLE
Define methods missing for incremental redisplay

### DIFF
--- a/GUI/McCLIM-ESA/Flexichain-output-history/flexichain-output-history.lisp
+++ b/GUI/McCLIM-ESA/Flexichain-output-history/flexichain-output-history.lisp
@@ -108,6 +108,15 @@
 	(when (= (clim:bounding-rectangle-width existing) (width history))
 	  (recompute-width history)))))
 
+(defmethod clim:clear-output-record ((history flexichain-output-history))
+  (let ((chain (lines history)))
+    (flexichain:delete-elements* chain 0 (flexichain:nb-elements chain))))
+
+(defmethod clim:add-output-record
+    ((record clim:standard-updating-output-record)
+     (history flexichain-output-history))
+  (flexichain:push-end (lines history) record))
+
 (defmethod clim:map-over-output-records-containing-position
     (function
      (history flexichain-output-history)


### PR DESCRIPTION
Add clim:clear-output-record and clim:add-output-record to
climacs-flexichain-output-history so that it will work with a pane that
uses incremental-redisplay.