### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+Documentation/* linguist-documentation
+Papers/Incremental-parsing/* linguist-documentation


### PR DESCRIPTION
This humble PR seeks to exclude the tex documentation from github's language stats, for this repository to be recognized as Common Lisp code, and so than it's easier to find on github search results, it's easier to discover, it counts as CL activity and not Tex for popular analysis,…

mechanism based on https://github.com/github/linguist

Regards