### PR TITLE
Improvements for display performance and quality

### DIFF
--- a/GUI/McCLIM-ESA/View/Common-Lisp/common-lisp-view.lisp
+++ b/GUI/McCLIM-ESA/View/Common-Lisp/common-lisp-view.lisp
@@ -154,41 +154,42 @@
                   start-column-number
                   end-line-number
                   end-column-number)
-  (if (= start-line-number end-line-number)
-      (let* ((contents (climacs-syntax-common-lisp:line-contents
-                        cache start-line-number))
-             (string (coerce contents 'string)))
-        (draw-interval pane
-                       start-line-number
-                       string
-                       start-column-number
-                       end-column-number))
-      (progn (let* ((first (climacs-syntax-common-lisp:line-contents
-                            cache start-line-number))
-                    (string (coerce first 'string)))
-               (draw-interval pane
-                              start-line-number
-                              string
-                              start-column-number
-                              (length first)))
-             (let* ((last (climacs-syntax-common-lisp:line-contents
-                           cache end-line-number))
-                    (string (coerce last 'string)))
-               (draw-interval pane
-                              end-line-number
-                              string
-                              0
-                              end-column-number))
-             (loop for line-number from (1+ start-line-number)
-                     to (1- end-line-number)
-                   for contents = (climacs-syntax-common-lisp:line-contents
-                                   cache line-number)
-                   for string = (coerce contents 'string)
-                   do (draw-interval pane
-                                     line-number
-                                     string
-                                     0
-                                     (length contents))))))
+  (cond ((= start-line-number end-line-number)
+         (let ((contents (climacs-syntax-common-lisp:line-contents
+                          cache start-line-number)))
+           (declare (type string contents))
+           (draw-interval pane
+                          start-line-number
+                          contents
+                          start-column-number
+                          end-column-number)))
+        (t
+         (let ((first (climacs-syntax-common-lisp:line-contents
+                       cache start-line-number)))
+           (declare (type string first))
+           (draw-interval pane
+                          start-line-number
+                          first
+                          start-column-number
+                          (length first)))
+         (let ((last (climacs-syntax-common-lisp:line-contents
+                      cache end-line-number)))
+           (declare (type string last))
+           (draw-interval pane
+                          end-line-number
+                          last
+                          0
+                          end-column-number))
+         (loop for line-number from (1+ start-line-number)
+               to (1- end-line-number)
+               for contents of-type string
+                  = (climacs-syntax-common-lisp:line-contents
+                     cache line-number)
+               do (draw-interval pane
+                                 line-number
+                                 contents
+                                 0
+                                 (length contents))))))
 
 ;;; The parameters START-LINE, START-COLUMN, END-LINE, and END-COLUMN
 ;;; together define an initial area.  END-COLUMN may be NIL, meaning

--- a/Syntax/Common-Lisp/cache.lisp
+++ b/Syntax/Common-Lisp/cache.lisp
@@ -35,8 +35,7 @@
 (defgeneric push-to-suffix (cache wad)
   (:method ((cache cache) (wad wad))
     (assert (not (relative-p wad)))
-    (with-accessors ((suffix suffix))
-        cache
+    (with-accessors ((suffix suffix)) cache
       (unless (null suffix)
         (absolute-to-relative (first suffix) (start-line wad)))
       (push wad suffix))))
@@ -47,9 +46,7 @@
 
 (defgeneric push-to-prefix (cache wad)
   (:method ((cache cache) (wad wad))
-    (with-accessors ((prefix prefix))
-        cache
-      (push wad prefix))))
+    (push wad (prefix cache))))
 
 (defun pop-from-worklist (cache)
   (pop (worklist cache)))

--- a/Syntax/Common-Lisp/cache.lisp
+++ b/Syntax/Common-Lisp/cache.lisp
@@ -9,7 +9,9 @@
 ;;; asked for it.
 (defclass line ()
   ((%cluffer-line :initarg :cluffer-line :reader cluffer-line)
-   (%contents :initarg :contents :accessor contents)))
+   (%contents :initarg  :contents
+              :type     string
+              :accessor contents)))
 
 (defclass cache (flexichain-folio)
   ((%prefix :initform '() :accessor prefix)
@@ -146,9 +148,10 @@
           (push-to-residue cache wad)))))
 
 (defun handle-modified-line (cache line-number)
-  (let ((line (flexichain:element* (contents cache) line-number)))
-    (setf (contents line)
-          (cluffer:items (cluffer-line line))))
+  (let* ((line         (flexichain:element* (contents cache) line-number))
+         (cluffer-line (cluffer-line line))
+         (string       (coerce (cluffer:items cluffer-line) 'string)))
+    (setf (contents line) string))
   (loop until (next-wad-is-beyond-line-p cache line-number)
         do (process-next-wad cache line-number)))
 
@@ -199,8 +202,9 @@
                  (incf line-counter))
                (create (line)
                  (ensure-cache-initialized)
-                 (let ((temp (make-instance 'line :cluffer-line line
-                                                  :contents (cluffer:items line))))
+                 (let* ((string (coerce (cluffer:items line) 'string))
+                        (temp   (make-instance 'line :cluffer-line line
+                                                     :contents     string)))
                    (flexichain:insert* lines line-counter temp))
                  (handle-inserted-line cache line-counter)
                  (incf line-counter))

--- a/Syntax/Fundamental/analyzer.lisp
+++ b/Syntax/Fundamental/analyzer.lisp
@@ -12,7 +12,9 @@
    (%line :initarg :line :reader line)
    ;; This slot contains the contents of the line as it was when we
    ;; last updated the analyzer.
-   (%contents :initarg :contents :accessor contents)
+   (%contents :initarg  :contents
+              :type     string
+              :accessor contents)
    ;; This slot contains the number of entries in the list (prefix or
    ;; suffix) that this entry is a member of.
    (%list-length :initarg list-length :accessor list-length)))


### PR DESCRIPTION
* Avoid many `(coerce … 'string)` calls (the performance impact is significant).

* During display, decide earlier to entirely skip WADs that will not contribute to the visible text.

* Draw a thin cursor beneath the buffer text so that the characters of the buffer text do not jump around.