### PR TITLE
[BUG] • Fix documentation executables

### DIFF
--- a/Documentation/codify
+++ b/Documentation/codify
@@ -1,3 +1,4 @@
+#!/bin/bash
 OUTFILE=$(echo $1 | sed -e 's/lisp/code/')
 echo -n "\\" >$OUTFILE
 echo "begin{Verbatim}[frame=single]" >>$OUTFILE

--- a/Documentation/tex-dependencies
+++ b/Documentation/tex-dependencies
@@ -2,9 +2,9 @@
 
 #set -x
 TEXFILES=$(./strip-dependence inputtex $1)
-echo -n $TEXFILES
+printf " $TEXFILES "
 for i in $TEXFILES
 do
-    echo -n " " $(./tex-dependencies $i)
+    printf " $(./tex-dependencies $i) "
 done
 echo


### PR DESCRIPTION
On macOS, some of the documentation executables are broken preventing the Makefile from generating the documentation PDF.