### PR TITLE
add missing dependencies

### DIFF
--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -5,10 +5,19 @@ set -euo pipefail
 # Add dependencies URLs here
 #
 DEPENDENCIES="
+https://github.com/robert-strandh/Acclimation
+https://github.com/robert-strandh/Clump
 https://github.com/robert-strandh/cluffer
 https://github.com/robert-strandh/cluffer-emacs-compatibility
 https://github.com/robert-strandh/SICL
 https://github.com/robert-strandh/Stealth-mixin
+https://github.com/s-expressionists/Eclector
+#
+# Uncomment the following two dependencies to build the Climatis
+# (non-McClim) version of Second-CLimacs.
+#
+# https://github.com/robert-strandh/Climatis
+# https://github.com/Shinmera/trivial-benchmark
 "
 
 PROJECTS_DIRECTORY=${1:-"$HOME/quicklisp/local-projects/"}


### PR DESCRIPTION
Add missing dependencies to get-dependencies.sh.
Include those for the Climatis variant also, but leave them commented out.