### PR TITLE
Improve cursor behaviour

### DIFF
--- a/GUI/McCLIM-ESA/View/Common-Lisp/common-lisp-view.lisp
+++ b/GUI/McCLIM-ESA/View/Common-Lisp/common-lisp-view.lisp
@@ -96,7 +96,7 @@
        :closed t :filled t :ink ink)))
 
 (defun draw-cursor (pane x y height)
-  (clim:draw-rectangle* pane (1+ x) (- y height) (+ x 4) y
+  (clim:draw-rectangle* pane (1- x) (- y height) (+ x 2) y
                         :ink clim:+blue+))
 
 ;;; Draw an interval of text from a single line.  Optimize by not

--- a/GUI/McCLIM-ESA/View/Fundamental/view.lisp
+++ b/GUI/McCLIM-ESA/View/Fundamental/view.lisp
@@ -52,6 +52,10 @@
 
 (defgeneric draw-line (pane analyzer contents line-number))
 
+(defun draw-cursor (pane x y height)
+  (clim:draw-rectangle* pane (1- x) (- y height) (+ x 2) y
+                        :ink clim:+blue+))
+
 (defmethod draw-line (pane (analyzer output-history) contents line-number)
   (let* ((text-style (clim:medium-text-style pane))
          (text-height (clim:text-style-height text-style pane))
@@ -65,30 +69,23 @@
          (string (coerce contents 'string)))
     (if (= (cluffer:line-number cursor) line-number)
         (cond ((zerop cursor-column-number)
-               (clim:draw-rectangle* pane 1 (- y text-height) 4 y
-                                     :ink clim:+blue+)
+               (draw-cursor pane 1 y text-height)
                (unless (zerop (length string))
-                 (clim:draw-text* pane string 5 y)))
+                 (clim:draw-text* pane string 0 y)))
               ((= cursor-column-number (length string))
                (unless (zerop (length string))
                  (clim:draw-text* pane string 0 y))
                (let ((cursor-x (* (length string) text-width)))
-                 (clim:draw-rectangle* pane
-                                       (1+ cursor-x) (- y text-height)
-                                       (+ cursor-x 4) y
-                                       :ink clim:+blue+)))
+                 (draw-cursor pane cursor-x y text-height)))
               (t
                (unless (zerop (length string))
                  (clim:draw-text* pane string 0 y
                                   :start 0
                                   :end cursor-column-number))
                (let ((cursor-x (* cursor-column-number text-width)))
-                 (clim:draw-rectangle* pane
-                                       (1+ cursor-x) (- y text-height)
-                                       (+ cursor-x 4) y
-                                       :ink clim:+blue+)
+                 (draw-cursor pane cursor-x y text-height)
                (unless (zerop (length string))
-                 (clim:draw-text* pane string (+ cursor-x 5) y
+                 (clim:draw-text* pane string cursor-x y
                                   :start cursor-column-number)))))
         (unless (zerop (length string))
           (clim:draw-text* pane string 0 y)))))


### PR DESCRIPTION
Improve cursor behaviour, particularly in Fundamental mode.

In Common-Lisp mode:
Move the cursor one pixel to the left and make one pixel thinner, so that it does not overlap as much text. Perhaps on a higher resolution monitor, the cursor is a bit too thin? I can easily make it wider again and resubmit, if this is a problem.

In Fundamental Mode:
Make the cursor behave as it does in Common-Lisp mode. The previous behaviour made the text jump around in a disturbing manner.

Thanks.