### PR TITLE
Add spell checking based on the spell system

### DIFF
--- a/Code/Base/packages.lisp
+++ b/Code/Base/packages.lisp
@@ -49,6 +49,7 @@
            #:delete-word
            #:erase-word
            #:back-to-indentation
+           #:delete-indentation
            #:mark
            #:climacs-error
            #:mark-not-set

--- a/Code/Base/standard-buffer.lisp
+++ b/Code/Base/standard-buffer.lisp
@@ -327,3 +327,18 @@
                   (not (member (cluffer:item-after-cursor cursor)
                                '(#\Space #\Tab #\Backspace #\Page))))
         do (cluffer:forward-item cursor)))
+
+(defun delete-indentation (cursor)
+  ;; Join current and previous lines.
+  (beginning-of-line cursor)
+  (erase-item cursor)
+  ;; Replace all whitespace on the joined line before and after the
+  ;; cursor with a single space.
+  (loop for item = (item-before-cursor cursor)
+        while (member item '(#\Space #\Tab))
+        do (erase-item cursor))
+  (loop for item = (item-after-cursor cursor)
+        while (member item '(#\Space #\Tab))
+        do (delete-item cursor))
+  (insert-item cursor #\Space)
+  (backward-item cursor))

--- a/Code/GUI/McCLIM-ESA/Base/delete-table.lisp
+++ b/Code/GUI/McCLIM-ESA/Base/delete-table.lisp
@@ -70,5 +70,14 @@
     (base:unkill cursor)))
 
 (esa:set-key `(com-unkill)
-	     'delete-table
-	     '((#\y :control)))
+             'delete-table
+             '((#\y :control)))
+
+(clim:define-command (com-delete-indentation
+                      :name          t
+                      :command-table delete-table)
+    ()
+  (with-current-cursor (cursor)
+    (base:delete-indentation cursor)))
+
+(esa:set-key `(com-delete-indentation) 'delete-table '((#\^ :meta)))

--- a/Code/GUI/McCLIM-ESA/View/Common-Lisp/wad-drawing.lisp
+++ b/Code/GUI/McCLIM-ESA/View/Common-Lisp/wad-drawing.lisp
@@ -56,6 +56,18 @@
   (clim:with-drawing-options (pane :ink clim:+gray50+)
     (call-next-method)))
 
+(defmethod draw-wad :around ((wad cl-syntax::word-wad)
+                             start-ref pane cache first-line last-line)
+  (declare (ignore cache first-line last-line))
+  (if (cl-syntax:misspelled wad)
+      (clim:surrounding-output-with-border (pane :shape :underline
+                                                 :ink            clim:+orange+
+                                                 :padding        2
+                                                 :line-thickness 2
+                                                 :line-dashes    '(4 4))
+        (call-next-method))
+      (call-next-method)))
+
 (flet ((draw-underline (pane line-number wad)
          (multiple-value-bind (style-width style-height ascent) (text-style-dimensions pane)
            (let* ((start-column (cl-syntax:start-column wad))

--- a/Code/Syntax/Common-Lisp/packages.lisp
+++ b/Code/Syntax/Common-Lisp/packages.lisp
@@ -33,6 +33,8 @@
    #:comment-wad
    #:block-command-wad
    #:semicolon-comment-wad
+   #:word-wad
+   #:misspelled
    #:ignored-wad
    #:sharpsign-wad
    #:sharpsign-plus-wad

--- a/Code/Syntax/Common-Lisp/second-climacs-syntax-common-lisp.asd
+++ b/Code/Syntax/Common-Lisp/second-climacs-syntax-common-lisp.asd
@@ -2,7 +2,8 @@
   :depends-on ("second-climacs-base"
                "second-climacs-syntax-common-lisp-base"
                "second-climacs-syntax-common-lisp-indentation"
-               "utilities.print-tree")
+               "spell" ; for spell checking in comments
+               "utilities.print-tree") ; for debugging
   :serial t
   :components ((:file "folio")
                (:file "folio-stream")

--- a/Code/Syntax/Common-Lisp/wad.lisp
+++ b/Code/Syntax/Common-Lisp/wad.lisp
@@ -110,6 +110,10 @@
    ;; of the comment.
    (%semicolon-count :initarg :semicolon-count :reader semicolon-count)))
 
+(defclass word-wad (skipped-wad)
+  ((%misspelled :initarg :misspelled
+                :reader  misspelled)))
+
 (defclass ignored-wad (skipped-wad)
   ())
 


### PR DESCRIPTION
Only in line comments, not block comments or documentation strings for
now.